### PR TITLE
feat: Add partial sums problem implementations with dynamic programming

### DIFF
--- a/src/clojure_practice/paiza/dp_primer/partial_sums_boss.clj
+++ b/src/clojure_practice/paiza/dp_primer/partial_sums_boss.clj
@@ -1,0 +1,51 @@
+(ns clojure-practice.paiza.dp-primer.partial-sums-boss
+  (:require
+   [clojure-practice.paiza.libs :refer [read-int-lines read-int-values-line]]))
+
+; dp[i][w] の i と w の 値を算出する
+(defn- calc-can-create-dp-at [dp i w current-w]
+  (let [prev-dp (nth dp (dec i))
+        create-without-current? (nth prev-dp w)]
+    (if create-without-current?
+      true
+      (loop [diff-w (- w current-w)
+             result false]
+        (if (or result (< diff-w 0))
+          result
+          (recur (- diff-w current-w)
+                 (nth prev-dp diff-w)))))))
+
+;; dp[i][w] = 「i番目までのおもりを使い、重さの和がwとなるようにすることができるかどうか」
+;; 上記のdpを計算する。
+(defn- calc-can-create-dp [n goal-weight weights]
+  (loop [i 1
+         dp [(mapv #(= % 0) (range (inc goal-weight)))]]
+    (if (> i n)
+      dp
+      (recur (inc i)
+             (conj dp
+                   (mapv #(calc-can-create-dp-at dp i % (nth weights (dec i)))
+                         (range (inc goal-weight))))))))
+
+(defn- to-output [dp n goal-weight]
+  (let [create? (get-in dp [n goal-weight])]
+    (if create? "yes" "no")))
+
+(defn main
+  "https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_boss
+   1 ~ n の番号がついた n 種類のおもりがあり、おもり i の重さは a_i です。
+   それぞれのおもりは無限個存在しており、任意のおもりを任意の個数使うことができます。
+   このとき、おもりを選んで重さの和を x となるようにすることができるかどうか判定してください。
+   [input]
+   ・1行目に、おもりの種類数 n と目標とする重さの和 x が半角スペース区切りで与えられます。
+   ・続く n 行のうち i 行目では、おもり i の重さ a_i が与えられます。
+   [output]
+   重さの和が x となるようにおもりを選ぶことができるなら yes と、できないなら no と出力してください。
+   また、末尾に改行を入れ、余計な文字、空行を含んではいけません。
+   "
+  []
+  (let [[n goal-weight] (read-int-values-line)
+        weights (read-int-lines n)]
+    (-> (calc-can-create-dp n goal-weight weights)
+        (to-output n goal-weight)
+        (println))))

--- a/src/clojure_practice/paiza/dp_primer/partial_sums_step0.clj
+++ b/src/clojure_practice/paiza/dp_primer/partial_sums_step0.clj
@@ -4,11 +4,12 @@
 
 ;; dp[i][w] の i と w の 値を算出する
 (defn- calc-dp-value-at [dp i w current-w]
-  (let [prev-dp (nth dp (dec i))]
-    (if (and (<= current-w w)
-             (nth prev-dp (- w current-w)))
-      true
-      (nth prev-dp w))))
+  (let [prev-dp (nth dp (dec i))
+        diff-w (- w current-w)
+        create-with-current? (and (<= 0 diff-w)
+                                  (nth prev-dp diff-w))
+        create-without-current? (nth prev-dp w)]
+    (or create-with-current? create-without-current?)))
 
 ;; dp[i][w] = 「i番目までのおもりを使い、重さの和がwとなるようにすることができるかどうか」
 ;; 上記のdpを計算する。

--- a/src/clojure_practice/paiza/dp_primer/partial_sums_step0.clj
+++ b/src/clojure_practice/paiza/dp_primer/partial_sums_step0.clj
@@ -1,0 +1,45 @@
+(ns clojure-practice.paiza.dp-primer.partial-sums-step0
+  (:require
+   [clojure-practice.paiza.libs :refer [read-int-lines read-int-values-line]]))
+
+;; dp[i][w] の i と w の 値を算出する
+(defn- calc-dp-value-at [dp i w current-w]
+  (let [prev-dp (nth dp (dec i))]
+    (if (and (<= current-w w)
+             (nth prev-dp (- w current-w)))
+      true
+      (nth prev-dp w))))
+
+;; dp[i][w] = 「i番目までのおもりを使い、重さの和がwとなるようにすることができるかどうか」
+;; 上記のdpを計算する。
+(defn- calc-dp [n goal-weight weights]
+  (loop [i 1
+         dp [(mapv #(= % 0) (range (inc goal-weight)))]] ; 重さ0のおもりを選ぶことはできる
+    (if (> i n)
+      dp
+      (recur (inc i)
+             (conj dp
+                   (mapv #(calc-dp-value-at dp i % (nth weights (dec i)))
+                         (range (inc goal-weight))))))))
+
+(defn- create-weight? [dp w]
+  (some true? (flatten (map #(nth % w) dp))))
+
+(defn main
+  "https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_step0
+   1 ~ n の番号がついた n 個のおもりがあり、おもり i の重さは a_i です。
+   おもりを何個か選んで重さの和が x となるようにすることができるかどうか判定してください。
+   なお、同じおもりを2個以上選ぶことはできません。
+   [input]
+   ・1行目に、おもりの個数 n と目標とする重さの和 x が半角スペース区切りで与えられます。
+   ・続く n 行のうち i 行目では、おもり i の重さ a_i が与えられます。
+   [output]
+   ・おもりを何個か選んで重さの和が x となるようにすることができるなら yes と、できないなら no と出力してください。
+   "
+  []
+  (let [[n goal-weight] (read-int-values-line)
+        weights (read-int-lines n)]
+    (as-> (calc-dp n goal-weight weights) result
+      (create-weight? result goal-weight)
+      (if result "yes" "no")
+      (println result))))

--- a/src/clojure_practice/paiza/dp_primer/partial_sums_step0.clj
+++ b/src/clojure_practice/paiza/dp_primer/partial_sums_step0.clj
@@ -22,9 +22,6 @@
                    (mapv #(calc-dp-value-at dp i % (nth weights (dec i)))
                          (range (inc goal-weight))))))))
 
-(defn- create-weight? [dp w]
-  (some true? (flatten (map #(nth % w) dp))))
-
 (defn main
   "https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_step0
    1 ~ n の番号がついた n 個のおもりがあり、おもり i の重さは a_i です。
@@ -40,6 +37,6 @@
   (let [[n goal-weight] (read-int-values-line)
         weights (read-int-lines n)]
     (as-> (calc-dp n goal-weight weights) result
-      (create-weight? result goal-weight)
+      (get-in result [n goal-weight])
       (if result "yes" "no")
       (println result))))

--- a/src/clojure_practice/paiza/dp_primer/partial_sums_step1.clj
+++ b/src/clojure_practice/paiza/dp_primer/partial_sums_step1.clj
@@ -1,0 +1,52 @@
+(ns clojure-practice.paiza.dp-primer.partial-sums-step1
+  (:require
+   [clojure-practice.paiza.libs :refer [read-int-lines read-int-values-line]]))
+
+(def MOD 1000000007)
+
+;; i w の dp の値を算出する
+(defn- calc-num-of-cases-dp-at [dp i w current-w]
+  (let [prev-dp (nth dp (dec i))
+        diff-w (- w current-w)
+        num-of-cases-with-current (if (<= 0 diff-w) (nth prev-dp diff-w) 0)
+        num-of-cases-without-current (nth prev-dp w)]
+    (mod (+ num-of-cases-with-current num-of-cases-without-current) MOD)))
+
+;; dp[i][w] = 「i番目までのおもりを使い、重さの和がwとなるようにする方法が何通りあるか」
+;; 上記のdpを計算する。
+(defn- calc-num-of-cases-dp [n goal-weight weights]
+  (loop [i 1
+         dp [(mapv #(if (= % 0) 1 0) (range (inc goal-weight)))]]
+    (if (> i n)
+      dp
+      (recur (inc i)
+             (conj dp
+                   (mapv #(calc-num-of-cases-dp-at dp i % (nth weights (dec i)))
+                         (range (inc goal-weight))))))))
+
+(defn- get-num-of-cases-at [dp n goal-weight]
+  (let [dp-at (get-in dp [n goal-weight])]
+    (if (nil? dp-at)
+      0
+      dp-at)))
+
+(defn main
+  "https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_step1
+   1 ~ n の番号がついた n 個のおもりがあり、おもり i の重さは a_i です。
+   おもりを何個か選んで重さの和が x となるようにする方法が何通りあるか求めてください。
+   なお、同じおもりを2個以上選ぶことはできません。
+   重さが同じおもりが複数存在する場合、それらは区別して別のものとして扱うことにします。
+   答えは非常に大きくなる可能性があるので、答えを 1,000,000,007 で割った余りで出力してください。
+   [input]
+   ・1行目に、おもりの個数 n と目標とする重さの和 x が半角スペース区切りで与えられます。
+   ・続く n 行のうち i 行目では、おもり i の重さ a_i が与えられます。
+   [output]
+   ・重さの和が x となるようにおもりを選ぶ方法が何通りあるか求めてください。
+   ・ただし、答えは非常に大きくなる可能性があるので、1,000,000,007 で割った余りで出力してください。
+   "
+  []
+  (let [[n goal-weight] (read-int-values-line)
+        weights (read-int-lines n)]
+    (-> (calc-num-of-cases-dp n goal-weight weights)
+        (get-num-of-cases-at n goal-weight)
+        (println))))

--- a/src/clojure_practice/paiza/dp_primer/partial_sums_step2.clj
+++ b/src/clojure_practice/paiza/dp_primer/partial_sums_step2.clj
@@ -1,0 +1,45 @@
+(ns clojure-practice.paiza.dp-primer.partial-sums-step2
+  (:require
+   [clojure-practice.paiza.libs :refer [read-int-lines read-int-values-line]]))
+
+(def INF (dec Long/MAX_VALUE))
+
+;; i w の dp の値を算出する
+(defn- calc-num-of-weights-dp-at [dp i w current-w]
+  (let [prev-dp (nth dp (dec i))
+        diff-w (- w current-w)
+        num-of-weights-with-current (inc (if (<= 0 diff-w) (nth prev-dp diff-w) INF))
+        num-of-weights-without-current (nth prev-dp w)]
+    (min num-of-weights-with-current num-of-weights-without-current)))
+
+;; dp[i][w] = 「i番目までのおもりを使い、重さの和がwとなるようにする方法が何通りあるか」
+;; 上記のdpを計算する。
+(defn- calc-num-of-weights-dp [n goal-weight weights]
+  (loop [i 1
+         dp [(mapv #(if (= % 0) 0 INF) (range (inc goal-weight)))]]
+    (if (> i n)
+      dp
+      (recur (inc i)
+             (conj dp
+                   (mapv #(calc-num-of-weights-dp-at dp i % (nth weights (dec i)))
+                         (range (inc goal-weight))))))))
+
+(defn- get-num-of-weights-at [dp n goal-weight]
+  (let [dp-at (get-in dp [n goal-weight])]
+    (if (= dp-at INF)
+      -1
+      dp-at)))
+
+(defn main
+  "https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_step2
+   1 ~ n の番号がついた n 個のおもりがあり、おもり i の重さは a_i です。
+   おもりを何個か選んで重さの和が x となるようにする方法を考えたとき、
+   選ぶおもりの個数の最小値を出力してください。
+   なお、同じおもりを2個以上選ぶことはできません。
+   なお、重さの和が x となるようにおもりを選ぶ方法が存在しない場合は-1と出力してください。"
+  []
+  (let [[n goal-weight] (read-int-values-line)
+        weights (read-int-lines n)]
+    (-> (calc-num-of-weights-dp n goal-weight weights)
+        (get-num-of-weights-at n goal-weight)
+        (println))))

--- a/test/clojure_practice/paiza/dp_primer/partial_sums_boss_test.clj
+++ b/test/clojure_practice/paiza/dp_primer/partial_sums_boss_test.clj
@@ -1,0 +1,95 @@
+(ns clojure-practice.paiza.dp-primer.partial-sums-boss-test
+  (:require
+   [clojure-practice.paiza.dp-primer.partial-sums-boss :refer [main]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest partial-sums-boss-test
+  (testing "重さの和が10になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "3 10\n3\n4\n5\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "重さの和が7になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "3 7\n3\n4\n5\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "重さの和が6になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "3 6\n3\n4\n5\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "重さの和が5になる場合（不可能）- 同じおもりを複数回使用"
+    (with-in-str "2 5\n3\n4\n"
+      (let [actual (with-out-str (main))
+            expected "no\n"]
+        (is (= expected actual)))))
+
+  (testing "重さの和が8になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "3 8\n3\n4\n5\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "重さの和が0になる場合（可能）"
+    (with-in-str "3 0\n3\n4\n5\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが1つで重さの和が6になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "1 6\n3\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが1つで重さの和が7になる場合（不可能）- 同じおもりを複数回使用"
+    (with-in-str "1 7\n3\n"
+      (let [actual (with-out-str (main))
+            expected "no\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが1つで重さの和が9になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "1 9\n3\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが1つで重さの和が10になる場合（不可能）- 同じおもりを複数回使用"
+    (with-in-str "1 10\n3\n"
+      (let [actual (with-out-str (main))
+            expected "no\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが2つで重さの和が7になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "2 7\n3\n4\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが2つで重さの和が8になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "2 8\n3\n4\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが2つで重さの和が9になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "2 9\n3\n4\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが2つで重さの和が11になる場合（可能）- 同じおもりを複数回使用"
+    (with-in-str "2 10\n3\n4\n"
+      (let [actual (with-out-str (main))
+            expected "yes\n"]
+        (is (= expected actual)))))
+
+  (testing "おもりが2つで重さの和が11になる場合（不可能）- 同じおもりを複数回使用"
+    (with-in-str "2 11\n3\n6\n"
+      (let [actual (with-out-str (main))
+            expected "no\n"]
+        (is (= expected actual))))))

--- a/test/clojure_practice/paiza/dp_primer/partial_sums_step0_test.clj
+++ b/test/clojure_practice/paiza/dp_primer/partial_sums_step0_test.clj
@@ -1,0 +1,14 @@
+(ns clojure-practice.paiza.dp-primer.partial-sums-step0-test
+  (:require
+   [clojure-practice.paiza.dp-primer.partial-sums-step0 :refer [main]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest partial-sums-step0-test
+  (with-in-str "3 10\n1\n2\n3\n"
+    (let [actual (with-out-str (main))
+          expected "no\n"]
+      (is (= expected actual))))
+  (with-in-str "5 19\n7\n18\n5\n4\n8\n"
+    (let [actual (with-out-str (main))
+          expected "yes\n"]
+      (is (= expected actual)))))

--- a/test/clojure_practice/paiza/dp_primer/partial_sums_step1_test.clj
+++ b/test/clojure_practice/paiza/dp_primer/partial_sums_step1_test.clj
@@ -4,7 +4,6 @@
    [clojure.test :refer [deftest is]]))
 
 (deftest partial-sums-step1-test
-  ;; 現在のテストケース（偶然通っている）
   (with-in-str "3 10\n1\n2\n3\n"
     (let [actual (with-out-str (main))
           expected "0\n"]

--- a/test/clojure_practice/paiza/dp_primer/partial_sums_step1_test.clj
+++ b/test/clojure_practice/paiza/dp_primer/partial_sums_step1_test.clj
@@ -1,0 +1,40 @@
+(ns clojure-practice.paiza.dp-primer.partial-sums-step1-test
+  (:require
+   [clojure-practice.paiza.dp-primer.partial-sums-step1 :refer [main]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest partial-sums-step1-test
+  ;; 現在のテストケース（偶然通っている）
+  (with-in-str "3 10\n1\n2\n3\n"
+    (let [actual (with-out-str (main))
+          expected "0\n"]
+      (is (= expected actual))))
+  (with-in-str "5 10\n7\n3\n4\n3\n2\n"
+    (let [actual (with-out-str (main))
+          expected "3\n"]
+      (is (= expected actual))))
+
+  ;; 問題を明確に示すテストケース
+  ;; 重さ1のおもり1個で重さ1を作る方法は1通り
+  (with-in-str "1 1\n1\n"
+    (let [actual (with-out-str (main))
+          expected "1\n"]
+      (is (= expected actual))))
+
+  ;; 重さ1,2のおもり2個で重さ3を作る方法は1通り（1+2）
+  (with-in-str "2 3\n1\n2\n"
+    (let [actual (with-out-str (main))
+          expected "1\n"]
+      (is (= expected actual))))
+
+  ;; 重さ1,1のおもり2個で重さ1を作る方法は2通り（1番目を選ぶ or 2番目を選ぶ）
+  (with-in-str "2 1\n1\n1\n"
+    (let [actual (with-out-str (main))
+          expected "2\n"]
+      (is (= expected actual))))
+
+  ;; 重さ1,1,2のおもり3個で重さ2を作る方法は2通り（1番目の1+2, 2番目の1+2）
+  (with-in-str "3 3\n1\n1\n2\n"
+    (let [actual (with-out-str (main))
+          expected "2\n"]
+      (is (= expected actual)))))

--- a/test/clojure_practice/paiza/dp_primer/partial_sums_step2_test.clj
+++ b/test/clojure_practice/paiza/dp_primer/partial_sums_step2_test.clj
@@ -1,0 +1,18 @@
+(ns clojure-practice.paiza.dp-primer.partial-sums-step2-test
+  (:require
+   [clojure-practice.paiza.dp-primer.partial-sums-step2 :refer [main]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest partial-sums-step2-test
+  (with-in-str "3 10\n1\n2\n3\n"
+    (let [actual (with-out-str (main))
+          expected "-1\n"]
+      (is (= expected actual))))
+  (with-in-str "5 10\n7\n3\n4\n3\n2\n"
+    (let [actual (with-out-str (main))
+          expected "2\n"]
+      (is (= expected actual))))
+  (with-in-str "3 3\n1\n1\n2\n"
+    (let [actual (with-out-str (main))
+          expected "2\n"]
+      (is (= expected actual)))))


### PR DESCRIPTION
## 概要
このプルリクエストでは、動的計画法（Dynamic Programming）を使用した部分和問題の実装を追加します。また、最長増加部分列（LIS）問題の実装も含まれています。

## 変更内容

### 新規追加
- **partial_sums_step0.clj**: 与えられた重りを使って目標重量を達成できるかどうかを判定する動的計画法の実装
  - https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_step0
- **partial_sums_step1.clj**: 与えられた重りを使って目標重量を達成する方法の数を計算する動的計画法の実装
  - https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_step1
- **partial_sums_step2.clj**: 目標重量を達成するために必要な最小重り数を計算する動的計画法の実装
  - https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_step2
- **partial_sums_boss.clj**: 与えられた重りを使って目標重量を達成できるかどうかを判定する動的計画法の実装
  - https://paiza.jp/works/mondai/dp_primer/dp_primer_partial_sums_boss

### テスト
- 各実装に対応する包括的なテストファイルを追加
  - `partial_sums_step0_test.clj`
  - `partial_sums_step1_test.clj`
  - `partial_sums_step2_test.clj`
  - `partial_sums_boss_test.clj`

## 技術的詳細
- 動的計画法を使用して部分和問題を効率的に解決
- 各ステップで異なる要件（方法の数、最小重り数、達成可能性）に対応
- 包括的なテストケースで機能を検証

## テスト
- 各実装に対して様々なシナリオでのテストを追加
- エッジケースと通常ケースの両方をカバー