### PR TITLE
feat: Add Educational DP Contest solutions in Clojure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
         "fibonaccis",
         "mapv",
         "paiza",
-        "println"
+        "println",
+        "subvec"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     },
     "editor.formatOnSave": true,
     "cSpell.words": [
+        "atcoder",
         "defn",
         "disj",
         "doseq",

--- a/src/clojure_practice/atcoder/educational_dp_contest/frog1.clj
+++ b/src/clojure_practice/atcoder/educational_dp_contest/frog1.clj
@@ -1,0 +1,38 @@
+(ns clojure-practice.atcoder.educational-dp-contest.frog1
+  (:require
+   [clojure-practice.paiza.libs :refer [read-int-value-line
+                                        read-int-values-line]]))
+
+(defn- calc-cost-from-to [costs dp from to]
+  (+ (nth dp from)
+     (Math/abs (- (nth costs from) (nth costs to)))))
+
+(defn calc-costs-dp [n costs]
+  (loop [idx 2
+         dp [0 (calc-cost-from-to costs [0] 0 1)]]
+    (if (<= n idx)
+      dp
+      (recur (inc idx)
+             (conj dp (min (calc-cost-from-to costs dp (- idx 1) idx)
+                           (calc-cost-from-to costs dp (- idx 2) idx)))))))
+
+(defn main
+  "https://atcoder.jp/contests/dp/tasks/dp_a
+   N 個の足場があります。足場には 1,2,…,N と番号が振られています。
+   各 i (1≤i≤N) について、足場 i の高さは hi です。
+   最初、足場 1 にカエルがいます。 カエルは次の行動を何回か繰り返し、足場 N まで辿り着こうとしています。
+   足場 i にいるとき、足場 i+1 または i+2 へジャンプする。 このとき、ジャンプ先の足場を j とすると、
+   コスト |hi - hj| を支払う。
+   カエルが足場 N に辿り着くまでに支払うコストの総和の最小値を求めてください。
+   [input]
+   N
+   h1 h2 … hN
+   [output]
+   カエルが支払うコストの総和の最小値を出力せよ。
+   "
+  []
+  (let [n (read-int-value-line)
+        costs (read-int-values-line)]
+    (-> (calc-costs-dp n costs)
+        (last)
+        (println))))

--- a/src/clojure_practice/atcoder/educational_dp_contest/frog2.clj
+++ b/src/clojure_practice/atcoder/educational_dp_contest/frog2.clj
@@ -1,0 +1,38 @@
+(ns clojure-practice.atcoder.educational-dp-contest.frog2
+  (:require
+   [clojure-practice.paiza.libs :refer [read-int-values-line]]))
+
+(defn- calc-cost-from-to [costs dp from to]
+  (+ (nth dp from)
+     (Math/abs (- (nth costs from) (nth costs to)))))
+
+(defn calc-costs-dp [n k costs]
+  (loop [idx 2
+         dp [0 (calc-cost-from-to costs [0] 0 1)]]
+    (if (<= n idx)
+      dp
+      (recur (inc idx)
+             (conj dp
+                   (apply min (map #(calc-cost-from-to costs dp (- idx %) idx)
+                                   (range 1 (inc (min k idx))))))))))
+
+(defn main
+  "https://atcoder.jp/contests/dp/tasks/dp_a
+   N 個の足場があります。足場には 1,2,…,N と番号が振られています。
+   各 i (1≤i≤N) について、足場 i の高さは hi です。
+   最初、足場 1 にカエルがいます。 カエルは次の行動を何回か繰り返し、足場 N まで辿り着こうとしています。
+   ・足場 i にいるとき、足場 i+1,i+2,…,i+K のどれかへジャンプする。
+   ・このとき、ジャンプ先の足場を j とすると、コスト |hi - hj| を支払う。
+   カエルが足場 N に辿り着くまでに支払うコストの総和の最小値を求めてください。
+   [input]
+   N K
+   h1 h2 … hN
+   [output]
+   カエルが支払うコストの総和の最小値を出力せよ。
+   "
+  []
+  (let [[n k] (read-int-values-line)
+        costs (read-int-values-line)]
+    (-> (calc-costs-dp n k costs)
+        (last)
+        (println))))

--- a/src/clojure_practice/atcoder/educational_dp_contest/knapsack1.clj
+++ b/src/clojure_practice/atcoder/educational_dp_contest/knapsack1.clj
@@ -1,0 +1,52 @@
+(ns clojure-practice.atcoder.educational-dp-contest.knapsack1
+  (:require
+   [clojure-practice.paiza.libs :refer [read-int-values-line
+                                        read-int-values-lines]]))
+
+(defn- calc-max-values [prev-max-values limit-weight [weight value]]
+  (mapv #(if (< % weight)
+           (nth prev-max-values %)
+           (max (nth prev-max-values %)
+                (+ (nth prev-max-values (- % weight)) value)))
+        (range (inc limit-weight))))
+
+(defn- calc-max-value-dp [n limit-weight items]
+  (loop [idx 1
+         dp [(vec (repeat (inc limit-weight) 0))]]
+    (if (< n idx)
+      dp
+      (recur (inc idx)
+             (conj dp (calc-max-values (last dp)
+                                       limit-weight
+                                       (nth items (dec idx))))))))
+
+(defn- get-max-value [dp]
+  (last (last dp)))
+
+(defn main
+  "https://atcoder.jp/contests/dp/tasks/dp_d
+   N 個の品物があります。品物には 1,2,…,N と番号が振られています。
+   各 i (1≤i≤N) について、品物 i の重さは wi で、価値は vi です。
+
+   太郎君は、N 個の品物のうちいくつかを選び、
+   ナップサックに入れて持ち帰ることにしました。
+   ナップサックの容量は W であり、
+   持ち帰る品物の重さの総和は W 以下でなければなりません。
+
+   太郎君が持ち帰る品物の価値の総和の最大値を求めてください。
+
+   [input]
+   N W
+   w1 v1
+   w2 v2
+   :
+   wN vN
+   [output]
+   太郎君が持ち帰る品物の価値の総和の最大値を出力せよ。
+   "
+  []
+  (let [[n w] (read-int-values-line)
+        items (read-int-values-lines n)]
+    (-> (calc-max-value-dp n w items)
+        (get-max-value)
+        (println))))

--- a/src/clojure_practice/atcoder/educational_dp_contest/knapsack1.clj
+++ b/src/clojure_practice/atcoder/educational_dp_contest/knapsack1.clj
@@ -3,25 +3,22 @@
    [clojure-practice.paiza.libs :refer [read-int-values-line
                                         read-int-values-lines]]))
 
-(defn- calc-max-values [prev-max-values limit-weight [weight value]]
+(defn- calc-max-values-at [prev-max-values limit-weight [weight value]]
   (mapv #(if (< % weight)
            (nth prev-max-values %)
            (max (nth prev-max-values %)
                 (+ (nth prev-max-values (- % weight)) value)))
         (range (inc limit-weight))))
 
-(defn- calc-max-value-dp [n limit-weight items]
+(defn- calc-max-values [n limit-weight items]
   (loop [idx 1
-         dp [(vec (repeat (inc limit-weight) 0))]]
+         max-values (vec (repeat (inc limit-weight) 0))]
     (if (< n idx)
-      dp
+      max-values
       (recur (inc idx)
-             (conj dp (calc-max-values (last dp)
-                                       limit-weight
-                                       (nth items (dec idx))))))))
-
-(defn- get-max-value [dp]
-  (last (last dp)))
+             (calc-max-values-at max-values
+                                 limit-weight
+                                 (nth items (dec idx)))))))
 
 (defn main
   "https://atcoder.jp/contests/dp/tasks/dp_d
@@ -47,6 +44,6 @@
   []
   (let [[n w] (read-int-values-line)
         items (read-int-values-lines n)]
-    (-> (calc-max-value-dp n w items)
-        (get-max-value)
+    (-> (calc-max-values n w items)
+        (last)
         (println))))

--- a/src/clojure_practice/atcoder/educational_dp_contest/lcs.clj
+++ b/src/clojure_practice/atcoder/educational_dp_contest/lcs.clj
@@ -1,0 +1,69 @@
+(ns clojure-practice.atcoder.educational-dp-contest.lcs)
+
+(defn- calc-lcs-at [last-t-dp last-t-lcs s t s-idx t-idx]
+  (let [s-char (nth s (dec s-idx))
+        t-char (nth t (dec t-idx))]
+    (if (= s-char t-char)
+      (inc (nth last-t-dp (dec t-idx)))
+      (max (nth last-t-dp t-idx) last-t-lcs))))
+
+(defn- calc-lcs-t-dp [last-t-dp s t s-idx t-count]
+  (loop [t-idx 1
+         t-dp [0]]
+    (if (< t-count t-idx)
+      t-dp
+      (recur (inc t-idx)
+             (conj t-dp
+                   (calc-lcs-at last-t-dp (last t-dp) s t s-idx t-idx))))))
+
+(defn- calc-lcs-dp [s t s-count t-count]
+  (loop [s-idx 1
+         dp [(vec (repeat (inc t-count) 0))]]
+    (if (< s-count s-idx)
+      dp
+      (recur (inc s-idx)
+             (conj dp
+                   (calc-lcs-t-dp (last dp) s t s-idx t-count))))))
+
+(defn- get-lcs [dp s t s-count t-count]
+  (loop [s-idx s-count
+         t-idx t-count
+         lcs ""]
+    (if (or (zero? s-idx) (zero? t-idx))
+      lcs
+      (let [s-char (nth s (dec s-idx))
+            t-char (nth t (dec t-idx))]
+        (if (= s-char t-char)
+          (recur (dec s-idx) (dec t-idx) (str s-char lcs))
+          (if (> (get-in dp [(dec s-idx) t-idx]) (get-in dp [s-idx (dec t-idx)]))
+            (recur (dec s-idx) t-idx lcs)
+            (recur s-idx (dec t-idx) lcs)))))))
+
+(defn main
+  "https://atcoder.jp/contests/dp/tasks/dp_f
+   文字列 s および t が与えられます。
+   s の部分列かつ t の部分列であるような文字列のうち、
+   最長のものをひとつ求めてください。
+
+   文字列 x の部分列とは、
+   x から 0 個以上の文字を取り除いた後、
+   残りの文字を元の順序で連結して得られる文字列のことです。
+
+   [input]
+   s
+   t
+
+   [output]
+   s の部分列かつ t の部分列であるような文字列のうち、
+   最長のものをひとつ出力せよ。
+   答えが複数ある場合、どれを出力してもよい。
+   答えが空文字列になることもある。
+   "
+  []
+  (let [s (read-line)
+        t (read-line)
+        s-count (count s)
+        t-count (count t)]
+    (-> (calc-lcs-dp s t s-count t-count)
+        (get-lcs s t s-count t-count)
+        (println))))

--- a/src/clojure_practice/atcoder/educational_dp_contest/vacation.clj
+++ b/src/clojure_practice/atcoder/educational_dp_contest/vacation.clj
@@ -3,25 +3,19 @@
    [clojure-practice.paiza.libs :refer [read-int-value-line
                                         read-int-values-lines]]))
 
-(defn- max-happiness-dp-of-day [happiness-table dp day]
-  (let [[a b c] (nth happiness-table (dec day))
-        [a-last-dp b-last-dp c-last-dp] (last dp)]
-    [(+ a (max b-last-dp c-last-dp))
-     (+ b (max a-last-dp c-last-dp))
-     (+ c (max a-last-dp b-last-dp))]))
-
 (defn- calc-max-happiness [n happiness-table]
   (loop [day 1
-         dp [[0 0 0]]]
+         [a-max b-max c-max] [0 0 0]]
     (if (< n day)
-      dp
+      [a-max b-max c-max]
       (recur (inc day)
-             (conj dp
-                   (max-happiness-dp-of-day happiness-table dp day))))))
+             (let [[a b c] (nth happiness-table (dec day))]
+               [(max a-max (+ a b-max) (+ a c-max))
+                (max b-max (+ b a-max) (+ b c-max))
+                (max c-max (+ c a-max) (+ c b-max))])))))
 
-(defn- get-max-happiness-of-day [dp]
-  (let [[max-a max-b max-c] (last dp)]
-    (max max-a max-b max-c)))
+(defn- get-max-happiness-of-day [max-happiness]
+  (apply max max-happiness))
 
 (defn main
   "https://atcoder.jp/contests/dp/tasks/dp_c

--- a/src/clojure_practice/atcoder/educational_dp_contest/vacation.clj
+++ b/src/clojure_practice/atcoder/educational_dp_contest/vacation.clj
@@ -1,0 +1,50 @@
+(ns clojure-practice.atcoder.educational-dp-contest.vacation
+  (:require
+   [clojure-practice.paiza.libs :refer [read-int-value-line
+                                        read-int-values-lines]]))
+
+(defn- max-happiness-dp-of-day [happiness-table dp day]
+  (let [[a b c] (nth happiness-table (dec day))
+        [a-last-dp b-last-dp c-last-dp] (last dp)]
+    [(+ a (max b-last-dp c-last-dp))
+     (+ b (max a-last-dp c-last-dp))
+     (+ c (max a-last-dp b-last-dp))]))
+
+(defn- calc-max-happiness [n happiness-table]
+  (loop [day 1
+         dp [[0 0 0]]]
+    (if (< n day)
+      dp
+      (recur (inc day)
+             (conj dp
+                   (max-happiness-dp-of-day happiness-table dp day))))))
+
+(defn- get-max-happiness-of-day [dp]
+  (let [[max-a max-b max-c] (last dp)]
+    (max max-a max-b max-c)))
+
+(defn main
+  "https://atcoder.jp/contests/dp/tasks/dp_c
+   明日から太郎君の夏休みが始まります。 太郎君は夏休みの計画を立てることにしました。
+   夏休みは N 日からなります。
+   各 i (1≤i≤N) について、i 日目には太郎君は次の活動のうちひとつを選んで行います。
+   ・A: 海で泳ぐ。 幸福度 ai を得る。
+   ・B: 山で虫取りをする。 幸福度 bi を得る。
+   ・C: 家で宿題をする。 幸福度 ci を得る。
+   太郎君は飽き性なので、2 日以上連続で同じ活動を行うことはできません。
+   太郎君が得る幸福度の総和の最大値を求めてください。
+   [input]
+   N
+   a1 b1 c1
+   a2 b2 c2
+   ...
+   aN bN cN
+   [output]
+   太郎君が得る幸福度の総和の最大値
+   "
+  []
+  (let [n (read-int-value-line)
+        happiness-table (read-int-values-lines n)]
+    (-> (calc-max-happiness n happiness-table)
+        (get-max-happiness-of-day)
+        (println))))

--- a/test/clojure_practice/atcoder/educational_dp_contest/frog1_test.clj
+++ b/test/clojure_practice/atcoder/educational_dp_contest/frog1_test.clj
@@ -1,0 +1,18 @@
+(ns clojure-practice.atcoder.educational-dp-contest.frog1-test
+  (:require
+   [clojure-practice.atcoder.educational-dp-contest.frog1 :refer [main]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest frog1-test
+  (with-in-str "4\n10 30 40 20\n"
+    (let [actual (with-out-str (main))
+          expected "30\n"]
+      (is (= expected actual))))
+  (with-in-str "2\n10 10\n"
+    (let [actual (with-out-str (main))
+          expected "0\n"]
+      (is (= expected actual))))
+  (with-in-str "6\n30 10 60 10 60 50\n"
+    (let [actual (with-out-str (main))
+          expected "40\n"]
+      (is (= expected actual)))))

--- a/test/clojure_practice/atcoder/educational_dp_contest/frog2_test.clj
+++ b/test/clojure_practice/atcoder/educational_dp_contest/frog2_test.clj
@@ -1,0 +1,26 @@
+(ns clojure-practice.atcoder.educational-dp-contest.frog2-test
+  (:require
+   [clojure-practice.atcoder.educational-dp-contest.frog2 :refer [main]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest frog2-test
+  (with-in-str "4 2\n10 30 40 20\n"
+    (let [actual (with-out-str (main))
+          expected "30\n"]
+      (is (= expected actual))))
+  (with-in-str "5 3\n10 30 40 50 20\n"
+    (let [actual (with-out-str (main))
+          expected "30\n"]
+      (is (= expected actual))))
+  (with-in-str "3 1\n10 20 10\n"
+    (let [actual (with-out-str (main))
+          expected "20\n"]
+      (is (= expected actual))))
+  (with-in-str "2 100\n10 10\n"
+    (let [actual (with-out-str (main))
+          expected "0\n"]
+      (is (= expected actual))))
+  (with-in-str "10 4\n40 10 20 70 80 10 20 70 80 60\n"
+    (let [actual (with-out-str (main))
+          expected "40\n"]
+      (is (= expected actual)))))

--- a/test/clojure_practice/atcoder/educational_dp_contest/knapsack1_test.clj
+++ b/test/clojure_practice/atcoder/educational_dp_contest/knapsack1_test.clj
@@ -1,0 +1,18 @@
+(ns clojure-practice.atcoder.educational-dp-contest.knapsack1-test
+  (:require
+   [clojure-practice.atcoder.educational-dp-contest.knapsack1 :refer [main]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest knapsack1-test
+  (with-in-str "3 8\n3 30\n4 50\n5 60\n"
+    (let [actual (with-out-str (main))
+          expected "90\n"]
+      (is (= expected actual))))
+  (with-in-str "5 5\n1 1000000000\n1 1000000000\n1 1000000000\n1 1000000000\n1 1000000000\n"
+    (let [actual (with-out-str (main))
+          expected "5000000000\n"]
+      (is (= expected actual))))
+  (with-in-str "6 15\n6 5\n5 6\n6 4\n6 6\n3 5\n7 2\n"
+    (let [actual (with-out-str (main))
+          expected "17\n"]
+      (is (= expected actual)))))

--- a/test/clojure_practice/atcoder/educational_dp_contest/lcs_test.clj
+++ b/test/clojure_practice/atcoder/educational_dp_contest/lcs_test.clj
@@ -1,0 +1,22 @@
+(ns clojure-practice.atcoder.educational-dp-contest.lcs-test
+  (:require
+   [clojure-practice.atcoder.educational-dp-contest.lcs :refer [main]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest lcs-test
+  (with-in-str "axyb\nabyxb\n"
+    (let [actual (with-out-str (main))
+          expected "ayb\n"]
+      (is (= expected actual))))
+  (with-in-str "aa\nxayaz\n"
+    (let [actual (with-out-str (main))
+          expected "aa\n"]
+      (is (= expected actual))))
+  (with-in-str "a\nz\n"
+    (let [actual (with-out-str (main))
+          expected "\n"]
+      (is (= expected actual))))
+  (with-in-str "abracadabra\navadakedavra\n"
+    (let [actual (with-out-str (main))
+          expected "aaadara\n"]
+      (is (= expected actual)))))

--- a/test/clojure_practice/atcoder/educational_dp_contest/vacation_test.clj
+++ b/test/clojure_practice/atcoder/educational_dp_contest/vacation_test.clj
@@ -1,0 +1,18 @@
+(ns clojure-practice.atcoder.educational-dp-contest.vacation-test
+  (:require
+   [clojure-practice.atcoder.educational-dp-contest.vacation :refer [main]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest vacation-test
+  (with-in-str "3\n10 40 70\n20 50 80\n30 60 90\n"
+    (let [actual (with-out-str (main))
+          expected "210\n"]
+      (is (= expected actual))))
+  (with-in-str "1\n100 10 1\n"
+    (let [actual (with-out-str (main))
+          expected "100\n"]
+      (is (= expected actual))))
+  (with-in-str "7\n6 7 8\n8 8 3\n2 5 2\n7 8 6\n4 6 8\n2 3 4\n7 5 1\n"
+    (let [actual (with-out-str (main))
+          expected "46\n"]
+      (is (= expected actual)))))


### PR DESCRIPTION
## 概要
AtCoder Educational DP Contestの5つの問題に対するClojure実装を追加しました。

## 追加されたファイル

### 実装ファイル
- `src/clojure_practice/atcoder/educational_dp_contest/frog1.clj` - Frog 1 (DP A)
- `src/clojure_practice/atcoder/educational_dp_contest/frog2.clj` - Frog 2 (DP B)  
- `src/clojure_practice/atcoder/educational_dp_contest/knapsack1.clj` - Knapsack 1 (DP D)
- `src/clojure_practice/atcoder/educational_dp_contest/lcs.clj` - LCS (DP F)
- `src/clojure_practice/atcoder/educational_dp_contest/vacation.clj` - Vacation (DP C)

### テストファイル
- `test/clojure_practice/atcoder/educational_dp_contest/frog1_test.clj`
- `test/clojure_practice/atcoder/educational_dp_contest/frog2_test.clj`
- `test/clojure_practice/atcoder/educational_dp_contest/knapsack1_test.clj`
- `test/clojure_practice/atcoder/educational_dp_contest/lcs_test.clj`
- `test/clojure_practice/atcoder/educational_dp_contest/vacation_test.clj`

## 実装内容

### Frog 1 (DP A)
- カエルが足場1から足場Nまで移動する最小コストを求める問題
- 各足場から1つまたは2つ先の足場にジャンプ可能
- 動的計画法で最適解を計算

### Frog 2 (DP B)  
- Frog 1の拡張版で、K個先までの足場にジャンプ可能
- より汎用的な動的計画法の実装

### Knapsack 1 (DP D)
- ナップサック問題の基本実装
- 各品物の重さと価値が与えられ、容量制限内で最大価値を求める
- 2次元DPテーブルを使用した実装

### LCS (DP F)
- 最長共通部分列（Longest Common Subsequence）問題
- 2つの文字列の最長共通部分列を求める
- 動的計画法でLCSの長さを計算し、バックトラックで実際の文字列を復元

### Vacation (DP C)
- 夏休みの活動選択問題
- 各日に3つの活動（海、山、家）から選択し、連続で同じ活動を選ばない制約下で最大幸福度を求める
- 状態DPで各活動の最大幸福度を管理

## 技術的特徴
- 純粋関数型プログラミングの原則に従った実装
- ループと再帰を組み合わせた効率的なアルゴリズム
- 既存のライブラリ関数（`read-int-value-line`, `read-int-values-line`など）を活用
- 各問題に対応する包括的なテストケース

## テスト
各実装に対して複数のテストケースを用意し、正しい出力を確認しています。