### PR TITLE
Euclidean primer part1

### DIFF
--- a/src/clojure_practice/paiza/euclidean_primer/ax+by=c.clj
+++ b/src/clojure_practice/paiza/euclidean_primer/ax+by=c.clj
@@ -1,0 +1,16 @@
+(ns clojure-practice.paiza.euclidean-primer.ax+by=c
+  (:require
+   [clojure.string :as string]))
+
+(defn- resolve-xy
+  [[a b c]]
+  (if (= c (mod a b))
+    [1 (- (quot a b))]
+    [(- (quot b a)) 1]))
+
+(defn main
+  []
+  (->> (map #(Long/parseLong %) (string/split (read-line) #" "))
+       (resolve-xy)
+       (string/join " ")
+       (println)))

--- a/src/clojure_practice/paiza/euclidean_primer/extgcd.clj
+++ b/src/clojure_practice/paiza/euclidean_primer/extgcd.clj
@@ -1,0 +1,18 @@
+(ns clojure-practice.paiza.euclidean-primer.extgcd
+  (:require
+   [clojure.string :as string]))
+
+(defn- ectgcd
+  [[a b]]
+  (if (zero? b)
+    [a 1 0]
+    (let [[c x y] (ectgcd [b (mod a b)])]
+      [c y (- x (* (quot a b) y))])))
+
+(defn main
+  []
+  (->> (map #(Long/parseLong %) (string/split (read-line) #" "))
+       (ectgcd)
+       (rest)
+       (string/join " ")
+       (println)))

--- a/src/clojure_practice/paiza/euclidean_primer/extgcd.clj
+++ b/src/clojure_practice/paiza/euclidean_primer/extgcd.clj
@@ -2,17 +2,17 @@
   (:require
    [clojure.string :as string]))
 
-(defn- ectgcd
+(defn- extgcd
   [[a b]]
   (if (zero? b)
     [a 1 0]
-    (let [[c x y] (ectgcd [b (mod a b)])]
+    (let [[c x y] (extgcd [b (mod a b)])]
       [c y (- x (* (quot a b) y))])))
 
 (defn main
   []
   (->> (map #(Long/parseLong %) (string/split (read-line) #" "))
-       (ectgcd)
+       (extgcd)
        (rest)
        (string/join " ")
        (println)))

--- a/src/clojure_practice/paiza/euclidean_primer/lcm.clj
+++ b/src/clojure_practice/paiza/euclidean_primer/lcm.clj
@@ -1,0 +1,23 @@
+(ns clojure-practice.paiza.euclidean-primer.lcm
+  (:require
+   [clojure.string :as string]))
+
+(defn- gcd
+  [[a b]]
+  (loop [x a
+         y b]
+    (cond
+      (zero? x) y
+      (zero? y) x
+      (< x y) (recur x (mod y x))
+      :else (recur y (mod x y)))))
+
+(defn- lcm
+  [[a b]]
+  (/ (* a b) (gcd [a b])))
+
+(defn main
+  []
+  (->> (map #(Long/parseLong %) (string/split (read-line) #" "))
+       (lcm)
+       (println)))

--- a/src/clojure_practice/paiza/euclidean_primer/multi_gcd.clj
+++ b/src/clojure_practice/paiza/euclidean_primer/multi_gcd.clj
@@ -1,0 +1,27 @@
+(ns clojure-practice.paiza.euclidean-primer.multi-gcd)
+
+(defn- get-numbers-from-input
+  []
+  (let [size (Long/parseLong (read-line))]
+    (map #(Long/parseLong %)
+         (take size (repeatedly read-line)))))
+
+(defn- gcd
+  [[a b]]
+  (loop [x a
+         y b]
+    (cond
+      (zero? x) y
+      (zero? y) x
+      (< x y) (recur x (mod y x))
+      :else (recur y (mod x y)))))
+
+(defn- multi-gcd
+  [numbers]
+  (reduce (fn [acc n] (gcd [acc n])) numbers))
+
+(defn main
+  []
+  (->> (get-numbers-from-input)
+       (multi-gcd)
+       (println)))

--- a/src/clojure_practice/paiza/euclidean_primer/simple_gcd.clj
+++ b/src/clojure_practice/paiza/euclidean_primer/simple_gcd.clj
@@ -1,0 +1,19 @@
+(ns clojure-practice.paiza.euclidean-primer.simple-gcd
+  (:require
+   [clojure.string :as string]))
+
+(defn gcd
+  [[a b]]
+  (loop [x a
+         y b]
+    (cond
+      (zero? x) y
+      (zero? y) x
+      (< x y) (recur x (mod y x))
+      :else (recur y (mod x y)))))
+
+(defn main
+  []
+  (->> (map #(Long/parseLong %) (string/split (read-line) #" "))
+       (gcd)
+       (println)))

--- a/test/clojure_practice/paiza/euclidean_primer/ax+by=c_test.clj
+++ b/test/clojure_practice/paiza/euclidean_primer/ax+by=c_test.clj
@@ -1,0 +1,21 @@
+(ns clojure-practice.paiza.euclidean-primer.ax+by=c-test
+  (:require
+   [clojure-practice.paiza.euclidean-primer.ax+by=c :refer [main]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest ax+by=c
+  (testing "sample1"
+    (with-in-str "15 100 10"
+      (let [actual (with-out-str (main))
+            expected "-6 1\n"]
+        (is (= expected actual)))))
+  (testing "sample2"
+    (with-in-str "8373 24 21"
+      (let [actual (with-out-str (main))
+            expected "1 -348\n"]
+        (is (= expected actual)))))
+  (testing "sample3"
+    (with-in-str "3 1048 1"
+      (let [actual (with-out-str (main))
+            expected "-349 1\n"]
+        (is (= expected actual))))))

--- a/test/clojure_practice/paiza/euclidean_primer/extgcd_test.clj
+++ b/test/clojure_practice/paiza/euclidean_primer/extgcd_test.clj
@@ -1,0 +1,17 @@
+(ns clojure-practice.paiza.euclidean-primer.extgcd-test
+
+  (:require
+   [clojure-practice.paiza.euclidean-primer.extgcd :refer [main]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest extgcd
+  (testing "sample1"
+    (with-in-str "2944 3958\n"
+      (let [actual (with-out-str (main))
+            expected "-929 691\n"]
+        (is (= expected actual)))))
+  (testing "sample2"
+    (with-in-str "2 7\n"
+      (let [actual (with-out-str (main))
+            expected "-3 1\n"]
+        (is (= expected actual))))))

--- a/test/clojure_practice/paiza/euclidean_primer/lcm_test.clj
+++ b/test/clojure_practice/paiza/euclidean_primer/lcm_test.clj
@@ -1,0 +1,16 @@
+(ns clojure-practice.paiza.euclidean-primer.lcm-test
+  (:require
+   [clojure-practice.paiza.euclidean-primer.lcm :refer [main]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest lcm
+  (testing "sample1"
+    (with-in-str "6 39"
+      (let [actual (with-out-str (main))
+            expected "78\n"]
+        (is (= expected actual)))))
+  (testing "sample2"
+    (with-in-str "2464 2461"
+      (let [actual (with-out-str (main))
+            expected "6054704\n"]
+        (is (= expected actual))))))

--- a/test/clojure_practice/paiza/euclidean_primer/lcm_test.clj
+++ b/test/clojure_practice/paiza/euclidean_primer/lcm_test.clj
@@ -12,5 +12,5 @@
   (testing "sample2"
     (with-in-str "2464 2461"
       (let [actual (with-out-str (main))
-            expected "6054704\n"]
+            expected "6063904\n"]
         (is (= expected actual))))))

--- a/test/clojure_practice/paiza/euclidean_primer/multi_gcd_test.clj
+++ b/test/clojure_practice/paiza/euclidean_primer/multi_gcd_test.clj
@@ -3,7 +3,7 @@
    [clojure-practice.paiza.euclidean-primer.multi-gcd :refer [main]]
    [clojure.test :refer [deftest is testing]]))
 
-(deftest chinese-remainder-theorem
+(deftest multi-gcd
   (testing "sample1"
     (with-in-str "3\n6\n18\n30"
       (let [actual (with-out-str (main))

--- a/test/clojure_practice/paiza/euclidean_primer/multi_gcd_test.clj
+++ b/test/clojure_practice/paiza/euclidean_primer/multi_gcd_test.clj
@@ -1,0 +1,16 @@
+(ns clojure-practice.paiza.euclidean-primer.multi-gcd-test
+  (:require
+   [clojure-practice.paiza.euclidean-primer.multi-gcd :refer [main]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest chinese-remainder-theorem
+  (testing "sample1"
+    (with-in-str "3\n6\n18\n30"
+      (let [actual (with-out-str (main))
+            expected "6\n"]
+        (is (= expected actual)))))
+  (testing "sample2"
+    (with-in-str "5\n7\n10\n30\n55\n175"
+      (let [actual (with-out-str (main))
+            expected "1\n"]
+        (is (= expected actual))))))

--- a/test/clojure_practice/paiza/euclidean_primer/simple_gcd_test.clj
+++ b/test/clojure_practice/paiza/euclidean_primer/simple_gcd_test.clj
@@ -3,7 +3,7 @@
    [clojure-practice.paiza.euclidean-primer.simple-gcd :refer [main]]
    [clojure.test :refer [deftest is testing]]))
 
-(deftest chinese-remainder-theorem
+(deftest simple-gcd
   (testing "sample1"
     (with-in-str "45 15"
       (let [actual (with-out-str (main))

--- a/test/clojure_practice/paiza/euclidean_primer/simple_gcd_test.clj
+++ b/test/clojure_practice/paiza/euclidean_primer/simple_gcd_test.clj
@@ -1,0 +1,16 @@
+(ns clojure-practice.paiza.euclidean-primer.simple-gcd-test
+  (:require
+   [clojure-practice.paiza.euclidean-primer.simple-gcd :refer [main]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest chinese-remainder-theorem
+  (testing "sample1"
+    (with-in-str "45 15"
+      (let [actual (with-out-str (main))
+            expected "15\n"]
+        (is (= expected actual)))))
+  (testing "sample2"
+    (with-in-str "2 7"
+      (let [actual (with-out-str (main))
+            expected "1\n"]
+        (is (= expected actual))))))


### PR DESCRIPTION
This pull request adds several new Clojure implementations for basic number theory algorithms (GCD, LCM, extended GCD, and solving linear Diophantine equations) as well as corresponding test files for each implementation. The main focus is on providing clean, functional solutions and ensuring correctness with sample-based tests.

The most important changes are:

### New algorithm implementations

* Added `simple_gcd.clj` implementing the Euclidean algorithm for computing the greatest common divisor of two numbers.
* Added `multi_gcd.clj` for calculating the GCD of a list of numbers, including input parsing for multiple values.
* Added `lcm.clj` for computing the least common multiple using the GCD.
* Added `extgcd.clj` for the extended Euclidean algorithm, returning coefficients for Bézout's identity.
* Added `ax+by=c.clj` for solving linear Diophantine equations of the form ax + by = c.

### Test coverage

* Added corresponding test files for each new implementation, verifying correctness with sample inputs and expected outputs: `simple_gcd_test.clj` [[1]](diffhunk://#diff-72f33183cad5d835f98d2c25b24910b1542a3279f413579aabe461c91667458dR1-R16) `multi_gcd_test.clj` [[2]](diffhunk://#diff-a1a9de9fc06923a31ed782c25e9c6fe6680160ae2a15aed0d384d9e7ec799911R1-R16) `lcm_test.clj` [[3]](diffhunk://#diff-2dd303c9acd9867b62972f0fb196efd62b367c03b2398010421f147df3c3a309R1-R16) `extgcd_test.clj` [[4]](diffhunk://#diff-4371c79b267a7b72efc654a9f549bdacfb8920ccf941c30147b603d831460218R1-R17) and `ax+by=c_test.clj` [[5]](diffhunk://#diff-f87350db109a13f5fb295ddbba7159dbfabacf23293a991f98b01fd870e48e2bR1-R21)